### PR TITLE
Dockerfile: use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ MAINTAINER mlechner@bfs.de
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV OPENSSL_CONF=/etc/ssl/
+
 #
 # Install required packages
 #
 RUN mkdir -p /usr/share/man/man1/ && apt-get -qq update && apt-get -qq install \
-    curl unzip openjdk-11-jre-headless  git && \
+    curl unzip openjdk-11-jre-headless git && \
     apt-get -qq clean && rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,16 @@ ENV OPENSSL_CONF /etc/ssl/
 #
 # Install required packages
 #
+RUN apt-get -qq update && apt install -y wget apt-transport-https gpg
+RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+
+
+
+
 
 RUN mkdir -p /usr/share/man/man1/ && apt-get -qq update && apt-get -qq install \
-    curl unzip default-jre-headless git libapache2-mod-shib && \
+    curl unzip temurin-11-jre  git libapache2-mod-shib && \
     apt-get -qq clean && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 80 81 82 83 84

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,25 +13,16 @@
 # The LADA-application will be available under http://yourdockerhost:8182
 #
 
-FROM httpd:2.4 AS build
+FROM debian:11-slim AS build
 MAINTAINER mlechner@bfs.de
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV OPENSSL_CONF /etc/ssl/
-
+ENV OPENSSL_CONF=/etc/ssl/
 #
 # Install required packages
 #
-RUN apt-get -qq update && apt install -y wget apt-transport-https gpg
-RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
-RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
-
-
-
-
-
 RUN mkdir -p /usr/share/man/man1/ && apt-get -qq update && apt-get -qq install \
-    curl unzip temurin-11-jre  git && \
+    curl unzip openjdk-11-jre-headless  git && \
     apt-get -qq clean && rm -rf /var/lib/apt/lists/*
 
 
@@ -68,7 +59,7 @@ RUN sed -i -e "/Lada.clientVersion/s/';/ $(git rev-parse --short HEAD)';/" app.j
 RUN echo build $(grep Lada.clientVersion app.js | cut -d '=' -f 2 | cut -d "'" -f 2) && ./docker-build-app.sh
 
 
-FROM httpd:2.4
+FROM httpd:2.4 AS deploy
 MAINTAINER mlechner@bfs.de
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
### Problem:
The `httpd:2.4` Docker container is now based on `boookworm`, which does no longer contain `openjdk-11-jre-headless`. Sencha's ant based build tool requires Nashorn to process .xml files containing JavaScript, but Nashorn was removed in JRE15, so building with the current Dockerfile throws an error.

### Solution(s):
This PR contains 3 commits which all solve the problem in different ways:

  * The first one simply adds an external source for JRE 11.
  * The second one splits the process into two stages both based on `httpd:2.4`. Only the first one requires the external source for JRE 11 and the second one simply copies the files under `/usr/local/lada` (except for the vhosts file).
  * The third commit uses the Debian image `debian:11-slim` (i.e., bullseye) instead of `httpd:2.4`. This ensures that the package `openjdk-11-jre-headless` is still available without external resources.

The two intermediate commits are intentionally part of this PR to pinpoint potential issues.